### PR TITLE
Fix incorrect saturation value sent back to SmartThings

### DIFF
--- a/apps/capability_sample/caps_colorControl.c
+++ b/apps/capability_sample/caps_colorControl.c
@@ -57,7 +57,7 @@ static void caps_colorControl_attr_color_send(caps_colorControl_data_t *caps_dat
             NULL);
 
     value[1].type = IOT_CAP_VAL_TYPE_NUMBER;
-    value[1].number = caps_data->hue_value;
+    value[1].number = caps_data->saturation_value;
 
     cap_evt[1] = st_cap_create_attr(caps_data->handle,
             (char *) caps_helper_colorControl.attr_saturation.name,

--- a/apps/rtl8721c/light_example/main/caps_colorControl.c
+++ b/apps/rtl8721c/light_example/main/caps_colorControl.c
@@ -57,7 +57,7 @@ static void caps_colorControl_attr_color_send(caps_colorControl_data_t *caps_dat
             NULL);
 
     value[1].type = IOT_CAP_VAL_TYPE_NUMBER;
-    value[1].number = caps_data->hue_value;
+    value[1].number = caps_data->saturation_value;
 
     cap_evt[1] = st_cap_create_attr(caps_data->handle,
             (char *) caps_helper_colorControl.attr_saturation.name,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to the SmartThings Device SDK(STDK for short) project.
Please read & check through marking lists before submitting pull requests.
-->

## Marking lists
- [x] I have read the [Contributing Guidelines](https://github.com/SmartThingsCommunity/st-device-sdk-c/blob/master/CONTRIBUTING.md).
- [x] I have read the [Samsung Individual CLA](https://github.com/SmartThingsCommunity/st-device-sdk-c/blob/master/doc/SAMSUNGCLA.docx) and agree with it
     * We (SmartThings Device SDK team) may ask you to sign it for larger changes. In this case, once we receive it, we'll be able to accept your pull requests according to relevant laws.

- I submitted this PR against the correct branch:
  - [x] This pull-request is based on the latest [develop](https://github.com/SmartThingsCommunity/st-device-sdk-c-ref/tree/develop) branch.
  - [x] I have ensured local tests pass about my code changes.

## License

Your contribution will be licensed under the [Apache License Ver2.0](https://github.com/SmartThingsCommunity/st-device-sdk-c-ref/blob/master/LICENSE).
