### PR TITLE
Add airQualityHealthConcern capability sample

### DIFF
--- a/apps/capability_sample/CAPABILITY_GAP_REPORT.md
+++ b/apps/capability_sample/CAPABILITY_GAP_REPORT.md
@@ -1,0 +1,221 @@
+# Capability Gap Report
+
+This report compares the capability samples in `apps/capability_sample` against the official SmartThings standard capability list.
+
+Checked date: 2026-04-24
+
+Official references:
+- Production capabilities: https://developer.smartthings.com/docs/devices/capabilities/capabilities-reference
+- Proposed capabilities: https://developer.smartthings.com/docs/devices/capabilities/proposed
+- Raw capability data used for comparison: `https://developer.smartthings.com/capabilities`
+
+Comparison rule:
+- Local sample capability IDs were collected from `caps_{CAPABILITY}.c/.h` filenames in this directory.
+- Official capability IDs were collected from the SmartThings raw capability JSON.
+- Official statuses included in the main comparison: `live`, `proposed`
+
+## Summary
+
+- Local sample capabilities: 98
+- Official `live` capabilities: 136
+- Official `proposed` capabilities: 123
+- Official `live + proposed` capabilities: 259
+- Missing from local samples: 167
+  - Missing `live`: 53
+  - Missing `proposed`: 114
+- Local capabilities that are no longer `live` or `proposed`: 6
+
+## Missing Live Capabilities
+
+```text
+activitySensor
+airConditionerFanMode
+airConditionerMode
+atmosphericPressureMeasurement
+audioNotification
+audioStream
+audioTrackData
+batteryLevel
+bypassable
+chime
+currentMeasurement
+demandResponseLoadControl
+dewPoint
+elevatorCall
+filterState
+formaldehydeHealthConcern
+gasDetector
+hardwareFault
+healthCheck
+humidifierMode
+infraredLevel
+keypadInput
+laundryWasherRinseMode
+laundryWasherSpinSpeed
+lockCodes
+mediaTrackControl
+nitrogenDioxideHealthConcern
+nitrogenDioxideMeasurement
+notification
+occupancySensor
+ovenMode
+ozoneHealthConcern
+ozoneMeasurement
+pestControl
+powerConsumptionReport
+precipitationSensor
+radonMeasurement
+riceCooker
+robotCleanerCleaningMode
+robotCleanerOperatingState
+statelessPowerButton
+statelessPowerToggleButton
+temperatureLevel
+temperatureSetpoint
+tvChannel
+videoCamera
+videoCapture
+videoStream
+washerOperatingState
+webrtc
+windMode
+windowShadeLevel
+windowShadePreset
+```
+
+## Missing Proposed Capabilities
+
+```text
+alarmSensor
+applianceUtilization
+audioCapture
+audioRecording
+batchGasConsumptionReport
+cameraEvent
+cameraPreset
+cameraPrivacyMode
+cameraViewportSettings
+carbonMonoxideHealthConcern
+chargePointState
+chargingState
+coffeeMakerOperation
+color
+colorMode
+consumable
+consumableLife
+containerState
+cookTime
+deliveryRobotCall
+dishwasherMode
+doorState
+drivingStatus
+dryerMode
+endToEndEncryption
+endToEndEncryptionState
+estimatedTimeOfArrival
+evseChargingSession
+evseState
+faceRecognition
+fanDirection
+fanMode
+fanSpeedPercent
+feederOperatingState
+feederPortion
+flowMeasurement
+foodWasteDryingGrinder
+gasConsumptionReport
+geofence
+geolocation
+gridState
+hdr
+imageControl
+knob
+level
+lightControllerMode
+localMediaStorage
+lockAlarm
+lockAliro
+lockCredentials
+lockSchedules
+lockUsers
+massageIntensityChange
+massageIntensityControl
+massageOperating
+massageOperatingState
+massageTimeChange
+massageTimeControl
+mechanicalPanTiltZoom
+mediaGroup
+mediaPresets
+motionBed
+movementSensor
+multipleZonePresence
+nightVision
+operationalState
+petActivity
+plantCultivation
+pumpControlMode
+pumpOperationMode
+rainSensor
+refrigerationSetpoint
+relativeBrightness
+safetySwitch
+safetyValve
+sceneActivity
+scenes
+scent
+serviceArea
+soilMoistureMeasurement
+sounds
+speechRecognition
+speechSynthesis
+statelessCurtainPowerButton
+statelessScenes
+switchState
+thermostatWaterHeatingSetpoint
+threadBorderRouter
+threadNetwork
+vehicleBattery
+vehicleDoorState
+vehicleEngine
+vehicleFuelLevel
+vehicleHvac
+vehicleHvacRemoteSwitch
+vehicleInformation
+vehicleOdometer
+vehicleRange
+vehicleTirePressureMonitor
+vehicleWarning
+vehicleWindowState
+videoCapture2
+videoStreamSettings
+washerMode
+waterFlowAlarm
+waterMeter
+waterPressureMeasurement
+waterTemperatureMeasurement
+waterUsageMeter
+wifiInformation
+windSpeed
+windowShadeTiltLevel
+wirelessOperatingMode
+zoneManagement
+```
+
+## Local Capabilities That Are Deprecated
+
+These exist in `apps/capability_sample`, but the official SmartThings data marks them as `deprecated` rather than `live` or `proposed`.
+
+```text
+execute
+garageDoorControl
+operatingState
+samsungTV
+thermostatSetpoint
+timedSession
+```
+
+## Notes
+
+- `antiSnoringPillow`, `filterStatus`, `radonHealthConcern`, `rapidCooling`, `tvocHealthConcern` are already covered locally and are still in the official `proposed` set.
+- This report only checks presence or absence of capability sample files. It does not verify whether each sample fully models every attribute, command, enum, or schema change in the latest SmartThings definition.

--- a/apps/capability_sample/caps_airQualityHealthConcern.c
+++ b/apps/capability_sample/caps_airQualityHealthConcern.c
@@ -1,0 +1,120 @@
+/* ***************************************************************************
+ *
+ * Copyright 2019-2022 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "st_dev.h"
+#include "caps_airQualityHealthConcern.h"
+
+static int caps_airQualityHealthConcern_attr_airQualityHealthConcern_str2idx(const char *value)
+{
+    int index;
+
+    for (index = 0; index < CAP_ENUM_AIRQUALITYHEALTHCONCERN_AIRQUALITYHEALTHCONCERN_VALUE_MAX; index++) {
+        if (!strcmp(value, caps_helper_airQualityHealthConcern.attr_airQualityHealthConcern.values[index])) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+static const char *caps_airQualityHealthConcern_get_airQualityHealthConcern_value(caps_airQualityHealthConcern_data_t *caps_data)
+{
+    if (!caps_data) {
+        printf("caps_data is NULL\n");
+        return NULL;
+    }
+    return caps_data->airQualityHealthConcern_value;
+}
+
+static void caps_airQualityHealthConcern_set_airQualityHealthConcern_value(caps_airQualityHealthConcern_data_t *caps_data, const char *value)
+{
+    if (!caps_data) {
+        printf("caps_data is NULL\n");
+        return;
+    }
+    if (caps_data->airQualityHealthConcern_value) {
+        free(caps_data->airQualityHealthConcern_value);
+    }
+    caps_data->airQualityHealthConcern_value = strdup(value);
+}
+
+static void caps_airQualityHealthConcern_attr_airQualityHealthConcern_send(caps_airQualityHealthConcern_data_t *caps_data)
+{
+    int sequence_no = -1;
+
+    if (!caps_data || !caps_data->handle) {
+        printf("fail to get handle\n");
+        return;
+    }
+    if (!caps_data->airQualityHealthConcern_value) {
+        printf("value is NULL\n");
+        return;
+    }
+
+    ST_CAP_SEND_ATTR_STRING(caps_data->handle,
+            (char *)caps_helper_airQualityHealthConcern.attr_airQualityHealthConcern.name,
+            caps_data->airQualityHealthConcern_value,
+            NULL,
+            NULL,
+            sequence_no);
+
+    if (sequence_no < 0)
+        printf("fail to send airQualityHealthConcern value\n");
+    else
+        printf("Sequence number return : %d\n", sequence_no);
+}
+
+static void caps_airQualityHealthConcern_init_cb(IOT_CAP_HANDLE *handle, void *usr_data)
+{
+    caps_airQualityHealthConcern_data_t *caps_data = usr_data;
+    if (caps_data && caps_data->init_usr_cb)
+        caps_data->init_usr_cb(caps_data);
+    caps_airQualityHealthConcern_attr_airQualityHealthConcern_send(caps_data);
+}
+
+caps_airQualityHealthConcern_data_t *caps_airQualityHealthConcern_initialize(IOT_CTX *ctx, const char *component, void *init_usr_cb, void *usr_data)
+{
+    caps_airQualityHealthConcern_data_t *caps_data = NULL;
+
+    caps_data = malloc(sizeof(caps_airQualityHealthConcern_data_t));
+    if (!caps_data) {
+        printf("fail to malloc for caps_airQualityHealthConcern_data\n");
+        return NULL;
+    }
+
+    memset(caps_data, 0, sizeof(caps_airQualityHealthConcern_data_t));
+
+    caps_data->init_usr_cb = init_usr_cb;
+    caps_data->usr_data = usr_data;
+
+    caps_data->get_airQualityHealthConcern_value = caps_airQualityHealthConcern_get_airQualityHealthConcern_value;
+    caps_data->set_airQualityHealthConcern_value = caps_airQualityHealthConcern_set_airQualityHealthConcern_value;
+    caps_data->attr_airQualityHealthConcern_str2idx = caps_airQualityHealthConcern_attr_airQualityHealthConcern_str2idx;
+    caps_data->attr_airQualityHealthConcern_send = caps_airQualityHealthConcern_attr_airQualityHealthConcern_send;
+    if (ctx) {
+        caps_data->handle = st_cap_handle_init(ctx, component, caps_helper_airQualityHealthConcern.id, caps_airQualityHealthConcern_init_cb, caps_data);
+    }
+    if (!caps_data->handle) {
+        printf("fail to init airQualityHealthConcern handle\n");
+    }
+
+    return caps_data;
+}

--- a/apps/capability_sample/caps_airQualityHealthConcern.h
+++ b/apps/capability_sample/caps_airQualityHealthConcern.h
@@ -1,0 +1,43 @@
+/* ***************************************************************************
+ *
+ * Copyright 2019-2022 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "caps/iot_caps_helper_airQualityHealthConcern.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct caps_airQualityHealthConcern_data {
+    IOT_CAP_HANDLE* handle;
+    void *usr_data;
+    void *cmd_data;
+
+    char *airQualityHealthConcern_value;
+
+    const char *(*get_airQualityHealthConcern_value)(struct caps_airQualityHealthConcern_data *caps_data);
+    void (*set_airQualityHealthConcern_value)(struct caps_airQualityHealthConcern_data *caps_data, const char *value);
+    int (*attr_airQualityHealthConcern_str2idx)(const char *value);
+    void (*attr_airQualityHealthConcern_send)(struct caps_airQualityHealthConcern_data *caps_data);
+
+    void (*init_usr_cb)(struct caps_airQualityHealthConcern_data *caps_data);
+} caps_airQualityHealthConcern_data_t;
+
+caps_airQualityHealthConcern_data_t *caps_airQualityHealthConcern_initialize(IOT_CTX *ctx, const char *component, void *init_usr_cb, void *usr_data);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- add capability_sample wrapper files for airQualityHealthConcern
- update the capability gap report to include the new sample
- keep the implementation aligned with existing HealthConcern capability patterns